### PR TITLE
feat: adiciona atividade GitHub Skills ao sistema de inscrições

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -57,6 +57,12 @@ activities = {
         "max_participants": 15,
         "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
     },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program.",
+        "schedule": "Thursdays, 4:00 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
+    },
     "Drama Club": {
         "description": "Act, direct, and produce plays and performances",
         "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",


### PR DESCRIPTION
Adiciona a atividade "GitHub Skills" ao dicionário de atividades, conforme solicitado na issue #6. Agora os alunos podem se inscrever para a nova atividade de certificação em GitHub.